### PR TITLE
Add usage of loading env vars in .env file

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ structlog = "^24.2.0"
 jedi = "0.18.0"
 parso = "0.8.0"
 openai = "^1.51.2"
+python-dotenv = "^1.0.0"
 
 [build-system]
 requires = ["poetry-core"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -484,3 +484,4 @@ typing-extensions==4.12.2 ; python_version >= "3.10" and python_version < "4.0" 
 urllib3==2.2.2 ; python_version >= "3.10" and python_version < "4.0" \
     --hash=sha256:a448b2f64d686155468037e1ace9f2d2199776e17f0a46610480d311f73e3472 \
     --hash=sha256:dd505485549a7a552833da5e6063639d0d177c04f23bc3864e41e5dc5f612168
+python-dotenv==1.0.0

--- a/vulnhuntr/LLMs.py
+++ b/vulnhuntr/LLMs.py
@@ -4,6 +4,9 @@ from pydantic import BaseModel, ValidationError
 import anthropic
 import os
 import openai
+import dotenv
+
+dotenv.load_dotenv()
 
 log = logging.getLogger(__name__)
 


### PR DESCRIPTION
Add the usage of loading environment variables from a `.env` file in `vulnhuntr/LLMs.py`.

* **Add dependency**: Add `python-dotenv` to `pyproject.toml` and `requirements.txt`.
* **Load environment variables**: Import `dotenv` and call `dotenv.load_dotenv()` at the beginning of `vulnhuntr/LLMs.py`.

